### PR TITLE
Intègre la configuration Firebase du projet outilsdemarche

### DIFF
--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -65,22 +65,18 @@ Cliquez sur **Publier**.
 
 ## 3. Donner la configuration à l'application
 
-Créez le fichier `frontend/.env.local` (il n'est pas committé dans git)
-avec les valeurs du bloc `firebaseConfig` copié à l'étape 1.3 :
+**Déjà fait** : la configuration du projet `outilsdemarche-e9671` est intégrée
+dans `frontend/src/firebase.js` (ces clés web ne sont pas des secrets : la
+sécurité repose sur les règles Firestore de l'étape 2).
 
-```
-REACT_APP_FIREBASE_API_KEY=AIza...
-REACT_APP_FIREBASE_AUTH_DOMAIN=outils-cgt-aveyron.firebaseapp.com
-REACT_APP_FIREBASE_PROJECT_ID=outils-cgt-aveyron
-REACT_APP_FIREBASE_STORAGE_BUCKET=outils-cgt-aveyron.appspot.com
-REACT_APP_FIREBASE_MESSAGING_SENDER_ID=1234567890
-REACT_APP_FIREBASE_APP_ID=1:1234567890:web:abcdef
-```
+Pour pointer un jour vers un autre projet Firebase sans toucher au code,
+définissez les variables `REACT_APP_FIREBASE_*` (fichier `frontend/.env.local`
+en local, ou **Settings > Environment Variables** sur Vercel) — elles ont
+priorité sur les valeurs intégrées. Modèle dans `frontend/.env.example`.
 
-> Ces clés web ne sont pas des secrets : la sécurité repose sur les règles
-> Firestore de l'étape 2. Sur Vercel (où le site est hébergé), ajoutez les
-> mêmes variables dans **Settings > Environment Variables** du projet, puis
-> relancez un déploiement pour qu'elles soient prises en compte.
+> ⚠️ Ne jamais mettre dans le code ou dans git une clé de **compte de
+> service** (fichier JSON contenant `private_key`) : celle-là est un vrai
+> secret d'administration, et l'application n'en a pas besoin.
 
 ## 4. Rebuilder et déployer
 

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -10,13 +10,17 @@ import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
+// Configuration du projet « outilsdemarche » (clés web publiques : la
+// sécurité repose sur les règles Firestore, pas sur ces valeurs).
+// Des variables d'environnement REACT_APP_FIREBASE_* peuvent les remplacer
+// pour pointer vers un autre projet sans toucher au code.
 const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || 'AIzaSyDHMoRY7pSUw-e-UNNO5qqRWeiiGF-5PGA',
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || 'outilsdemarche-e9671.firebaseapp.com',
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID || 'outilsdemarche-e9671',
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET || 'outilsdemarche-e9671.firebasestorage.app',
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID || '598409161770',
+  appId: process.env.REACT_APP_FIREBASE_APP_ID || '1:598409161770:web:66af9f1802f0435b1c6753'
 };
 
 // Firebase est considéré configuré si les deux clés essentielles sont là


### PR DESCRIPTION
Les clés web (publiques par conception) sont intégrées comme valeurs par défaut dans src/firebase.js ; les variables REACT_APP_FIREBASE_* restent prioritaires pour pointer vers un autre projet. Le site déployé active donc comptes et partage sans configuration Vercel supplémentaire.


Claude-Session: https://claude.ai/code/session_0129Gxb8maVTv86WyNjg3sqo