### PR TITLE
Démarche ouverte sur le schéma + compte administrateur

### DIFF
--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -34,32 +34,46 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Profil de l'utilisateur : lisible/modifiable par lui seul
+    // Comptes administrateurs (doit correspondre à src/config/admin.js)
+    function estAdmin() {
+      return request.auth != null &&
+        request.auth.token.email in ['leyrat.quentin@gmail.com'];
+    }
+
+    // Profil de l'utilisateur : lisible/modifiable par lui seul (+ admin)
     match /utilisateurs/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+      allow read, write: if (request.auth != null && request.auth.uid == uid) || estAdmin();
     }
 
     match /syndicats/{syndicatId} {
       // Tout utilisateur connecté peut lire une fiche syndicat
       // (nécessaire pour rejoindre avec un code) et en créer une.
+      // Seul l'admin peut modifier ou supprimer un espace.
       allow read: if request.auth != null;
       allow create: if request.auth != null;
+      allow update, delete: if estAdmin();
 
       // Membres : chacun peut s'ajouter lui-même, les membres se lisent
       match /membres/{uid} {
         allow read: if request.auth != null;
-        allow write: if request.auth != null && request.auth.uid == uid;
+        allow write: if (request.auth != null && request.auth.uid == uid) || estAdmin();
       }
 
-      // Données des outils : réservées aux membres de l'espace
+      // Données des outils : réservées aux membres de l'espace (+ admin)
       match /donnees/{document} {
-        allow read, write: if request.auth != null &&
-          exists(/databases/$(database)/documents/syndicats/$(syndicatId)/membres/$(request.auth.uid));
+        allow read, write: if (request.auth != null &&
+          exists(/databases/$(database)/documents/syndicats/$(syndicatId)/membres/$(request.auth.uid)))
+          || estAdmin();
       }
     }
   }
 }
 ```
+
+> **Compte administrateur** : `leyrat.quentin@gmail.com` voit sur la page
+> Compte un panneau listant tous les espaces syndicats (nom, code, membres)
+> et tous les comptes rattachés. Pour changer d'admin, modifiez l'adresse
+> dans `frontend/src/config/admin.js` **et** dans les règles ci-dessus.
 
 Cliquez sur **Publier**.
 

--- a/frontend/src/components/DemarcheModule/PhaseBesoins.js
+++ b/frontend/src/components/DemarcheModule/PhaseBesoins.js
@@ -120,7 +120,7 @@ function PhaseBesoins({ onAddTool }) {
                     onClick={() => onAddTool(tool)}
                     className={styles.toolButton}
                   >
-                    + Ajouter
+                    Ouvrir →
                   </button>
                 </div>
               ))}
@@ -210,7 +210,7 @@ function PhaseBesoins({ onAddTool }) {
             <svg xmlns="http://www.w3.org/2000/svg" className={styles.downloadIcon} viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
             </svg>
-            Télécharger les modèles de questionnaires
+            Ouvrir le questionnaire des besoins
           </button>
         </div>
       </div>

--- a/frontend/src/components/DemarcheModule/PhaseMobilisation.js
+++ b/frontend/src/components/DemarcheModule/PhaseMobilisation.js
@@ -86,7 +86,7 @@ function PhaseMobilisation({ onAddTool }) {
                     onClick={() => onAddTool(tool)}
                     className={styles.addButton}
                   >
-                    + Ajouter à ma boîte
+                    Ouvrir →
                   </button>
                 </div>
               ))}

--- a/frontend/src/components/pages/AdminPanel.js
+++ b/frontend/src/components/pages/AdminPanel.js
@@ -1,0 +1,146 @@
+// src/components/pages/AdminPanel.js
+// Panneau d'administration (visible uniquement pour les comptes admin,
+// voir src/config/admin.js) : vue d'ensemble des espaces syndicats créés
+// et des comptes militants, avec leur rattachement.
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../../firebase';
+import styles from './AdminPanel.module.css';
+
+function AdminPanel() {
+  const [syndicats, setSyndicats] = useState([]);
+  const [utilisateurs, setUtilisateurs] = useState([]);
+  const [chargement, setChargement] = useState(true);
+  const [erreur, setErreur] = useState('');
+
+  const charger = useCallback(async () => {
+    setChargement(true);
+    setErreur('');
+    try {
+      // Tous les espaces syndicats, avec leurs membres
+      const syndicatsSnap = await getDocs(collection(db, 'syndicats'));
+      const listeSyndicats = await Promise.all(
+        syndicatsSnap.docs.map(async (docSyndicat) => {
+          let membres = [];
+          try {
+            const membresSnap = await getDocs(collection(db, 'syndicats', docSyndicat.id, 'membres'));
+            membres = membresSnap.docs.map((m) => ({ uid: m.id, ...m.data() }));
+          } catch (e) {
+            // Les membres restent vides si la lecture échoue
+          }
+          return { id: docSyndicat.id, ...docSyndicat.data(), membres };
+        })
+      );
+      listeSyndicats.sort((a, b) => (b.creeLe?.seconds || 0) - (a.creeLe?.seconds || 0));
+      setSyndicats(listeSyndicats);
+
+      // Tous les comptes militants
+      const utilisateursSnap = await getDocs(collection(db, 'utilisateurs'));
+      setUtilisateurs(utilisateursSnap.docs.map((u) => ({ uid: u.id, ...u.data() })));
+    } catch (error) {
+      console.error('Erreur du panneau admin:', error);
+      setErreur(
+        "Impossible de charger les données d'administration. Vérifiez que les règles Firestore " +
+        "incluent la fonction estAdmin() avec votre adresse email (voir FIREBASE.md). " +
+        `Détail : ${error.code || error.message}`
+      );
+    } finally {
+      setChargement(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    charger();
+  }, [charger]);
+
+  const nomSyndicat = (syndicatId) =>
+    syndicats.find((s) => s.id === syndicatId)?.nom || '—';
+
+  const formatDate = (timestamp) =>
+    timestamp?.seconds ? new Date(timestamp.seconds * 1000).toLocaleDateString('fr-FR') : '—';
+
+  return (
+    <div className={styles.panneau}>
+      <div className={styles.entete}>
+        <h2 className={styles.titre}>🛡️ Administration</h2>
+        <button className={styles.boutonRafraichir} onClick={charger} disabled={chargement}>
+          {chargement ? 'Chargement...' : '↻ Actualiser'}
+        </button>
+      </div>
+
+      {erreur && <p className={styles.erreur}>{erreur}</p>}
+
+      {!chargement && !erreur && (
+        <>
+          <h3 className={styles.sousTitre}>
+            Espaces syndicats <span className={styles.compteur}>{syndicats.length}</span>
+          </h3>
+          {syndicats.length === 0 ? (
+            <p className={styles.vide}>Aucun espace syndicat créé pour l'instant.</p>
+          ) : (
+            <div className={styles.tableauScroll}>
+              <table className={styles.tableau}>
+                <thead>
+                  <tr>
+                    <th>Syndicat</th>
+                    <th>Code</th>
+                    <th>Membres</th>
+                    <th>Créé le</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {syndicats.map((s) => (
+                    <tr key={s.id}>
+                      <td><strong>{s.nom}</strong></td>
+                      <td><code className={styles.code}>{s.code}</code></td>
+                      <td>
+                        {s.membres.length > 0
+                          ? s.membres.map((m) => `${m.email}${m.role === 'admin' ? ' ★' : ''}`).join(', ')
+                          : '—'}
+                      </td>
+                      <td>{formatDate(s.creeLe)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <h3 className={styles.sousTitre}>
+            Comptes militants <span className={styles.compteur}>{utilisateurs.length}</span>
+          </h3>
+          {utilisateurs.length === 0 ? (
+            <p className={styles.vide}>Aucun compte n'a encore rejoint d'espace syndicat.</p>
+          ) : (
+            <div className={styles.tableauScroll}>
+              <table className={styles.tableau}>
+                <thead>
+                  <tr>
+                    <th>Email</th>
+                    <th>Syndicat</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {utilisateurs.map((u) => (
+                    <tr key={u.uid}>
+                      <td>{u.email}</td>
+                      <td>{nomSyndicat(u.syndicatId)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <p className={styles.note}>
+            ★ = créateur de l'espace. Les comptes qui se sont inscrits sans créer ni
+            rejoindre d'espace n'apparaissent que dans Firebase Console → Authentication.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default AdminPanel;

--- a/frontend/src/components/pages/AdminPanel.module.css
+++ b/frontend/src/components/pages/AdminPanel.module.css
@@ -1,0 +1,106 @@
+.panneau {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  margin-bottom: 1rem;
+  border-top: 4px solid #b71c1c;
+}
+
+.entete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.titre {
+  font-size: 1.25rem;
+  color: #b71c1c;
+  margin: 0;
+}
+
+.boutonRafraichir {
+  background: white;
+  color: #b71c1c;
+  border: 1px solid #b71c1c;
+  padding: 0.4rem 0.9rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.boutonRafraichir:disabled {
+  opacity: 0.5;
+}
+
+.sousTitre {
+  font-size: 1.05rem;
+  color: #333;
+  margin: 1.25rem 0 0.6rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.compteur {
+  background: #b71c1c;
+  color: white;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+}
+
+.tableauScroll {
+  overflow-x: auto;
+}
+
+.tableau {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.tableau th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: #f7f7f7;
+  color: #555;
+  border-bottom: 2px solid #e5e5e5;
+  white-space: nowrap;
+}
+
+.tableau td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f0f0f0;
+  color: #333;
+}
+
+.code {
+  background: #f5f5f5;
+  color: #b71c1c;
+  font-weight: 700;
+  padding: 0.1rem 0.5rem;
+  border-radius: 6px;
+  letter-spacing: 0.05em;
+}
+
+.vide {
+  color: #777;
+  font-size: 0.92rem;
+}
+
+.erreur {
+  color: #b71c1c;
+  background: #fdecea;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.note {
+  margin-top: 1rem;
+  font-size: 0.82rem;
+  color: #888;
+}

--- a/frontend/src/components/pages/ComptePage.js
+++ b/frontend/src/components/pages/ComptePage.js
@@ -6,6 +6,8 @@
 
 import React, { useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
+import { estAdmin } from '../../config/admin';
+import AdminPanel from './AdminPanel';
 import styles from './ComptePage.module.css';
 
 // Traduit les codes d'erreur Firebase en messages compréhensibles
@@ -96,11 +98,16 @@ function ComptePage() {
         <h1 className={styles.titre}>Mon compte</h1>
 
         <div className={styles.carte}>
-          <p>Connecté en tant que <strong>{user.email}</strong></p>
+          <p>
+            Connecté en tant que <strong>{user.email}</strong>
+            {estAdmin(user) && <span className={styles.badgeAdmin}> 🛡️ Administrateur</span>}
+          </p>
           <button className={styles.boutonSecondaire} onClick={() => soumettre(logout)} disabled={enCours}>
             Se déconnecter
           </button>
         </div>
+
+        {estAdmin(user) && <AdminPanel />}
 
         {syndicat ? (
           <div className={styles.carte}>

--- a/frontend/src/components/pages/ComptePage.module.css
+++ b/frontend/src/components/pages/ComptePage.module.css
@@ -131,3 +131,15 @@
   color: #777;
   padding: 2rem;
 }
+
+.badgeAdmin {
+  display: inline-block;
+  background: #b71c1c;
+  color: white;
+  font-size: 0.78rem;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}

--- a/frontend/src/components/pages/DemarcheSyndicalePage.js
+++ b/frontend/src/components/pages/DemarcheSyndicalePage.js
@@ -1,22 +1,41 @@
 // src/components/pages/DemarcheSyndicalePage.js
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate, Link } from 'react-router-dom';
 import styles from './DemarchePage.module.css';
 import TabNav from '../Modules/Demarche/TabNav';
 import PhaseBesoins from '../DemarcheModule/PhaseBesoins';
 import PhaseRevendications from '../DemarcheModule/PhaseRevendications';
 import SchemaGlobal from '../Modules/Demarche/SchemaGlobal';
 
+// Chaque « outil recommandé » de la démarche ouvre le vrai outil
+// de l'application qui lui correspond.
+function routePourOutil(nomOutil) {
+  const nom = nomOutil.toLowerCase();
+  if (nom.includes('questionnaire') || nom.includes('besoins') || nom.includes('consultation')) {
+    return '/questionnaire';
+  }
+  if (nom.includes('cahier') || nom.includes('revendica') || nom.includes('priorisation') || nom.includes('argument')) {
+    return '/cahier-revendicatif';
+  }
+  if (nom.includes('ag') || nom.includes('animation') || nom.includes('bilan participatif') || nom.includes('démocrat')) {
+    return '/assemblees';
+  }
+  if (nom.includes('communication') || nom.includes('mobilisation') || nom.includes('rapport de force') || nom.includes('action')) {
+    return '/plan-actions';
+  }
+  return '/parcours';
+}
+
 function DemarcheSyndicalePage() {
   // Récupérer les paramètres d'URL
   const location = useLocation();
+  const navigate = useNavigate();
   const queryParams = new URLSearchParams(location.search);
   const tabParam = queryParams.get('tab');
 
-  // États pour gérer les onglets, les sous-onglets et la sélection d'outils
+  // États pour gérer les onglets et les sous-onglets
   const [activeTab, setActiveTab] = useState(tabParam || 'ecole-democratie');
   const [activeSubTab, setActiveSubTab] = useState(null);
-  const [selectedTools, setSelectedTools] = useState([]);
 
   // Définition des onglets principaux avec leurs couleurs
   const tabs = [
@@ -47,7 +66,9 @@ function DemarcheSyndicalePage() {
         setActiveSubTab('types');
         break;
       case 'ecole-democratie':
-        setActiveSubTab('concept');
+        // La démarche s'ouvre directement sur le schéma global :
+        // c'est lui qui explique l'école de la démocratie d'un coup d'œil
+        setActiveSubTab('schema');
         break;
       default:
         setActiveSubTab(null);
@@ -63,15 +84,9 @@ function DemarcheSyndicalePage() {
     setActiveSubTab(subTabId);
   };
 
+  // Ouvre le vrai outil de l'application correspondant à l'outil recommandé
   const handleAddTool = (tool) => {
-    if (!selectedTools.includes(tool)) {
-      setSelectedTools([...selectedTools, tool]);
-      alert(`Outil "${tool}" ajouté à votre boîte à outils`);
-    }
-  };
-
-  const handleExportTools = () => {
-    alert("Fonctionnalité d'exportation à venir");
+    navigate(routePourOutil(tool));
   };
 
   return (
@@ -109,29 +124,30 @@ function DemarcheSyndicalePage() {
                 </blockquote>
               </div>
               <div className={styles.outilsBox}>
-                <h3 className={styles.outilsTitle}>Boîte à outils</h3>
+                <h3 className={styles.outilsTitle}>Les outils de la démarche</h3>
                 <p className={styles.outilsIntro}>
-                  Sélectionnez et exportez les outils qui vous aideront dans chaque phase.
+                  Chaque phase de la démarche s'appuie sur un outil concret de l'application :
                 </p>
-                <div className={styles.selectedTools}>
-                  <h4>Vos outils sélectionnés ({selectedTools.length})</h4>
-                  {selectedTools.length > 0 ? (
-                    <>
-                      <ul className={styles.toolsList}>
-                        {selectedTools.map((tool, index) => (
-                          <li key={index} className={styles.toolItem}>{tool}</li>
-                        ))}
-                      </ul>
-                      <button className={styles.exportButton} onClick={handleExportTools}>
-                        Exporter ma boîte à outils
-                      </button>
-                    </>
-                  ) : (
-                    <p className={styles.emptyTools}>
-                      Aucun outil sélectionné. Explorez les différentes phases pour ajouter des outils.
-                    </p>
-                  )}
-                </div>
+                <ul className={styles.toolsList}>
+                  <li className={styles.toolItem}>
+                    <Link to="/carto-syndicalisation?tab=cartographie">🗺️ Cartographie — connaître ses forces</Link>
+                  </li>
+                  <li className={styles.toolItem}>
+                    <Link to="/questionnaire">🗣️ Questionnaire — recueillir les besoins</Link>
+                  </li>
+                  <li className={styles.toolItem}>
+                    <Link to="/cahier-revendicatif">📖 Cahier revendicatif — construire les revendications</Link>
+                  </li>
+                  <li className={styles.toolItem}>
+                    <Link to="/assemblees">👥 Assemblées — faire vivre la démocratie</Link>
+                  </li>
+                  <li className={styles.toolItem}>
+                    <Link to="/retro-planning">📅 Rétro-planning — organiser l'action</Link>
+                  </li>
+                  <li className={styles.toolItem}>
+                    <Link to="/parcours">🧭 Mon parcours — suivre la démarche pas à pas</Link>
+                  </li>
+                </ul>
               </div>
             </div>
           )}
@@ -187,7 +203,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Guide d'organisation et de suivi d'une action
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Guide d'organisation et de suivi d'une action")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -203,7 +219,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Modèle de cahier revendicatif
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Modèle de cahier revendicatif")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -228,7 +244,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Guide d'organisation d'une AG de validation
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Guide d'organisation d'une AG de validation")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -244,7 +260,7 @@ function DemarcheSyndicalePage() {
                           Hiérarchisez les revendications selon leur impact.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Matrice de priorisation des revendications")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                       <div className={styles.outilCard}>
@@ -254,7 +270,7 @@ function DemarcheSyndicalePage() {
                           Synthétisez et analysez les besoins exprimés.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Guide d'analyse des besoins")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                       <div className={styles.outilCard}>
@@ -264,7 +280,7 @@ function DemarcheSyndicalePage() {
                           Exemples d'argumentaires pour soutenir les revendications.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Fiches argumentaires types")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                     </div>
@@ -323,7 +339,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Guide de communication de mobilisation
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Guide de communication de mobilisation")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -339,7 +355,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Kit d'argumentation persuasive
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Kit d'argumentation persuasive")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -355,7 +371,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Méthode de consolidation du rapport de force
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Méthode de consolidation du rapport de force")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -371,7 +387,7 @@ function DemarcheSyndicalePage() {
                           Pour gérer la communication en période de crise.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Kit de communication de crise")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                       <div className={styles.outilCard}>
@@ -381,7 +397,7 @@ function DemarcheSyndicalePage() {
                           Organisez des sessions de mobilisation efficaces.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Fiches de mobilisation")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                     </div>
@@ -453,7 +469,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Guide des principes démocratiques
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Guide des principes démocratiques")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -509,7 +525,7 @@ function DemarcheSyndicalePage() {
                         <strong>Outil recommandé :</strong> Kit d'animation démocratique
                       </p>
                       <button className={styles.addToolButton} onClick={() => handleAddTool("Kit d'animation démocratique")}>
-                        Ajouter à ma boîte à outils
+                        Ouvrir l'outil →
                       </button>
                     </div>
                   </div>
@@ -551,7 +567,7 @@ function DemarcheSyndicalePage() {
                           Méthodes et conseils pour organiser des assemblées générales efficaces et démocratiques.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Guide d'organisation d'AG")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                       
@@ -562,7 +578,7 @@ function DemarcheSyndicalePage() {
                           Questionnaires et formulaires pour recueillir efficacement les besoins des salariés.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Modèles de consultation")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                       
@@ -573,7 +589,7 @@ function DemarcheSyndicalePage() {
                           Techniques pour évaluer collectivement les actions et en tirer des enseignements.
                         </p>
                         <button className={styles.addToolButton} onClick={() => handleAddTool("Méthode de bilan participatif")}>
-                          Ajouter à ma boîte à outils
+                          Ouvrir l'outil →
                         </button>
                       </div>
                     </div>

--- a/frontend/src/config/admin.js
+++ b/frontend/src/config/admin.js
@@ -1,0 +1,11 @@
+// Administration de l'application.
+// Les comptes listés ici voient le panneau d'administration sur la page
+// Compte (liste des comptes militants et des espaces syndicats).
+// IMPORTANT : les règles Firestore (voir FIREBASE.md) doivent contenir
+// les mêmes adresses, sinon la lecture des données sera refusée.
+
+export const ADMIN_EMAILS = ['leyrat.quentin@gmail.com'];
+
+export function estAdmin(user) {
+  return Boolean(user?.email && ADMIN_EMAILS.includes(user.email.toLowerCase()));
+}


### PR DESCRIPTION
Page Démarche :
- L'École de la démocratie s'ouvre directement sur le Schéma global, qui porte l'explication de la démarche d'un coup d'œil
- Suppression de la « boîte à outils » fictive (les boutons ajoutaient des noms d'outils dans une liste sans usage) : chaque « outil recommandé » ouvre désormais le vrai outil de l'application (questionnaire, cahier revendicatif, assemblées, plan d'actions...)
- La vue d'ensemble liste les outils réels de chaque phase avec liens

Administration :
- leyrat.quentin@gmail.com (configurable dans src/config/admin.js) voit sur la page Compte un panneau listant tous les espaces syndicats (nom, code d'adhésion, membres, date) et tous les comptes rattachés
- Règles Firestore mises à jour dans FIREBASE.md : fonction estAdmin() donnant à l'admin la lecture de l'ensemble et la gestion des espaces (à republier dans la console Firebase)


Claude-Session: https://claude.ai/code/session_0129Gxb8maVTv86WyNjg3sqo